### PR TITLE
Set the missing variables needed with --laf.sct option.

### DIFF
--- a/titan.R
+++ b/titan.R
@@ -4380,6 +4380,17 @@ if (!is.na(argv$fge.file)) {
     proj4fge_from_nc<-list(var=argv$fge.proj4_var, att=argv$fge.proj4_att)
   }
 }
+if (!is.na(argv$laf.file) & argv$laf.sct) {
+  if (argv$proj4laf=="" & argv$laf.proj4_var=="" & argv$laf.proj4_att=="" ) {
+    laf.xy_as_vars<-T
+    proj4laf<-NULL
+    proj4laf_from_nc<-NULL
+  } else {
+    laf.xy_as_vars<-F
+    proj4laf<-argv$proj4laf
+    proj4laf_from_nc<-list(var=argv$laf.proj4_var, att=argv$laf.proj4_att)
+  }
+}
 # set the timestamp
 if (!is.na(argv$timestamp)) {
   if (is.na(argv$fg.t)) argv$fg.t<-argv$timestamp


### PR DESCRIPTION
Reading LAF data from NetCDF file does not work when the laf.sct
command line option is used. If the following variables are defined, the
data can be read and the analysis can be run successfully.
  proj4laf
  proj4laf_from_nc
  laf.xy_as_vars